### PR TITLE
prompt users to install the AsciiDoc plugin 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,5 @@ dist
 # TernJS port file
 .tern-port
 
-.idea
+.idea/*
+!.idea/externalDependencies.xml

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="org.asciidoctor.intellij.asciidoc" min-version="0.30.73" />
+  </component>
+</project>


### PR DESCRIPTION
... with of a recent version upon opening the project.

This is a nice feature and would prevent users to use an old version of the plugin. On the other hand it might be part of the tutorial to install the plugin? Up to you to merge or discard.