### PR TITLE
Add English workshop koans with language switcher

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -53,6 +53,33 @@ html, body {
     margin-bottom: 4px;
 }
 
+.lang-switch {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 12px;
+    font-size: 12px;
+}
+
+.lang-switch a {
+    padding: 3px 10px;
+    border-radius: 4px;
+    text-decoration: none;
+    color: #666;
+    border: 1px solid #d0d7de;
+    transition: all 0.2s;
+}
+
+.lang-switch a:hover {
+    border-color: #999;
+    color: #333;
+}
+
+.lang-switch a.active {
+    background: #1976d2;
+    color: #fff;
+    border-color: #1976d2;
+}
+
 #content {
     flex: 1;
     min-width: 0;

--- a/docs/workshop.js
+++ b/docs/workshop.js
@@ -1,4 +1,7 @@
 
+// Koan folder - can be overridden before loading this script
+var koanFolder = window.koanFolder || "workshop";
+
 let koanNum = getCookie("koanNum");
 if (koanNum === "") {
   koanNum = 1;
@@ -16,7 +19,7 @@ var totalExercises = 0;
 function countAllExercises() {
     var koan = 1;
     function fetchNext() {
-        fetch("workshop/koan_" + koan + ".adoc")
+        fetch(koanFolder + "/koan_" + koan + ".adoc")
             .then(function(response) {
                 if (!response.ok) {
                     // Done counting
@@ -79,7 +82,7 @@ function getCookie(cname) {
     return "";
 }
 function getKoan() {
-    fetch("workshop/koan_"+koanNum+".adoc")
+    fetch(koanFolder + "/koan_"+koanNum+".adoc")
         .then(function (response) {
             if (response.ok) {
                 return response.text();

--- a/docs/workshop_en.html
+++ b/docs/workshop_en.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AsciiDoc Koans - Workshop</title>
+    <title>AsciiDoc Koans - Workshop (English)</title>
     <script src="asciidoctor/browser/asciidoctor.js"></script>
     <script src="asciidoctor/browser/asciidoctor-kroki.js"></script>
     <link rel="stylesheet" href="asciidoctor/css/asciidoctor.css">
@@ -13,7 +13,7 @@
 <div class="layout">
     <div id="nav">
         <h2>AsciiDoc Koans</h2>
-        <div class="lang-switch"><a href="workshop.html" class="active">DE</a> <a href="workshop_en.html">EN</a></div>
+        <div class="lang-switch"><a href="workshop.html">DE</a> <a href="workshop_en.html" class="active">EN</a></div>
         <div class="progress-bar">
             <div class="progress-fill" id="progress-fill" style="width: 0%"></div>
             <span class="progress-label" id="progress-label">0 / 0</span>
@@ -43,6 +43,7 @@
     </div>
 </div>
 
+<script>var koanFolder = "workshop_en";</script>
 <script src="workshop.js"></script>
 </body>
 </html>

--- a/docs/workshop_en/koan_1.adoc
+++ b/docs/workshop_en/koan_1.adoc
@@ -1,0 +1,42 @@
+ifndef::imagesdir[:imagesdir: ../images]
+== Learning AsciiDoc with Koans
+
+This interactive tutorial teaches you the key elements of AsciiDoc syntax.
+Each page presents a small task by showing a formatted result.
+
+Your task is to format a plain text using AsciiDoc so that it matches the target result.
+When you succeed, the red border turns green and you can move on to the next task.
+
+Feel free to consult the documentation as you go.
+These exercises follow the https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference[Syntax Quick Reference]
+
+Let's start with...
+
+=== Paragraphs
+
+Paragraphs behave differently than you might expect.
+
+Try to achieve the formatting shown below.
+You need to split the text into two paragraphs and add a line break in the second one.
+
+'''
+//solution
+A first line in a first paragraph.
+
+A second line and +
+a third line in a second paragraph.
+
+'''
+//hint
+
+Here is the unformatted text and your input field.
+Change the source so that the formatted text matches the target above. +
+https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#paragraphs[📖, role=docs, target=docs]
+
+'''
+// Your input
+
+A first line in a first paragraph.
+A second line and
+a third line in a second paragraph.
+

--- a/docs/workshop_en/koan_10.adoc
+++ b/docs/workshop_en/koan_10.adoc
@@ -1,0 +1,104 @@
+ifndef::imagesdir[:imagesdir: ../images]
+
+//Recap
+
+=== Attributes and Document Properties
+
+Attributes control the behavior of AsciiDoc documents.
+
+https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes/[📖, role=docs, target=docs]
+
+The `:toc:` attribute generates a table of contents.
+
+'''
+//solution
+:toc:
+
+= My Document
+
+== Introduction
+
+== Architecture
+
+'''
+//hint
+`:toc:` at the top of the document. The headings automatically form the table of contents.
+
+'''
+= My Document
+
+== Introduction
+
+== Architecture
+
+''''
+
+The `:experimental:` attribute enables UI macros like `kbd:[]` for keyboard shortcuts.
+
+'''
+//solution
+:experimental:
+
+Press kbd:[Ctrl+S] to save.
+
+'''
+//hint
+`:experimental:` at the top, then `kbd:[keys]` in the text.
+
+'''
+Press Ctrl+S to save.
+
+''''
+
+The `:numbered:` attribute automatically numbers headings.
+
+'''
+//solution
+:numbered:
+
+= Project Handbook
+
+== Introduction
+
+== Architecture
+
+=== Building Blocks
+
+'''
+//hint
+`:numbered:` at the top of the document.
+
+'''
+= Project Handbook
+
+== Introduction
+
+== Architecture
+
+=== Building Blocks
+
+''''
+
+The `:sectanchors:` attribute adds clickable anchor links to each heading.
+
+'''
+//solution
+:sectanchors:
+
+= Project Handbook
+
+== Introduction
+
+== Architecture
+
+'''
+//hint
+`:sectanchors:` at the top of the document.
+
+'''
+= Project Handbook
+
+== Introduction
+
+== Architecture
+

--- a/docs/workshop_en/koan_2.adoc
+++ b/docs/workshop_en/koan_2.adoc
@@ -1,0 +1,60 @@
+Well done. +
+Let's continue with the next section.
+
+=== Simple Formatting
+
+Change the text below so that the words are displayed as bold, italic or monospace, as shown in the examples.
+
+https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#text-formatting[📖, role=docs, target=docs] <= here you can find help on AsciiDoc formatting.
+
+
+// Target
+'''
+
+This text is *bold*.
+
+//hint
+'''
+
+//Input
+'''
+This text is bold.
+
+''''
+
+
+// Target
+'''
+This text is _italic_.
+
+'''
+
+// Input
+'''
+This text is italic.
+
+''''
+
+// Target
+'''
+This text is `monospace`.
+
+'''
+
+// Input
+'''
+This text is monospace.
+
+''''
+...and now all together
+
+// Target
+'''
+
+Simple formatting includes *bold* and _italic_ or `monospace`.
+
+'''
+
+'''
+Simple formatting includes bold and italic or monospace.
+

--- a/docs/workshop_en/koan_3.adoc
+++ b/docs/workshop_en/koan_3.adoc
@@ -1,0 +1,51 @@
+ifndef::imagesdir[:imagesdir: ../images]
+
+=== Links
+
+Change the text below so that it links to https://google.com as shown.
+https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#links[📖, role=docs, target=docs]
+
+'''
+//solution
+A simple link looks like this: https://google.com
+
+'''
+//hint
+URLs are automatically displayed as links. Just write the URL in the text.
+
+'''
+// Your input
+
+A simple link looks like this:
+
+
+''''
+
+You can also display custom text as a link.
+
+'''
+
+You can also use custom link text: https://google.com[Google]
+
+'''
+//hint
+Square brackets after the URL: `https://url[link text]`
+
+'''
+You can also use custom link text: https://google.com
+
+''''
+
+For relative links within a project, use the `link:` macro.
+
+'''
+A relative link looks like this: link:about.html[]
+
+'''
+//hint
+`link:filename.html[]` for relative links.
+
+'''
+// Your input
+A relative link looks like this: about.html
+

--- a/docs/workshop_en/koan_4.adoc
+++ b/docs/workshop_en/koan_4.adoc
@@ -1,0 +1,81 @@
+ifndef::imagesdir[:imagesdir: ../images]
+
+//Recap
+
+=== Lists
+
+Lists are among the simple formatting elements.
+https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#lists[📖, role=docs, target=docs]
+
+'''
+//solution
+* Milk
+* Cheese
+* Eggs
+
+'''
+//hint
+Each list item starts with `*` followed by a space.
+
+'''
+// Your input
+Milk
+Cheese
+Eggs
+
+''''
+Nested lists use more asterisks for deeper levels.
+
+'''
+//solution
+* Shopping:
+** Milk
+** Cheese
+** Eggs
+
+'''
+//hint
+`**` for the second level, `***` for the third.
+
+'''
+Shopping:
+Milk
+Cheese
+Eggs
+
+''''
+Numbered lists use a period instead of an asterisk.
+
+'''
+//solution
+. Milk
+. Cheese
+. Eggs
+
+'''
+//hint
+`.` instead of `*` — numbering is automatic.
+
+'''
+Milk
+Cheese
+Eggs
+
+''''
+Checklists combine unordered lists with checkboxes.
+
+'''
+//solution
+* [ ] Milk
+* [ ] Cheese
+* [ ] Eggs
+
+'''
+//hint
+`* [ ]` for an unchecked box, `* [x]` for a checked one.
+
+'''
+Milk
+Cheese
+Eggs
+

--- a/docs/workshop_en/koan_5.adoc
+++ b/docs/workshop_en/koan_5.adoc
@@ -1,0 +1,112 @@
+ifndef::imagesdir[:imagesdir: ../images]
+
+//Recap
+
+=== Headings
+
+Headings are marked with one or more `=` followed by a space, depending on the depth.
+
+A heading with just _one_ `=` is the document title and should only appear once.
+
+Sub-documents should always start with heading level `==`.
+
+https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#section-titles[📖, role=docs, target=docs]
+
+'''
+//solution
+= Document Title (Level 0)
+
+== Level 1 Section Title
+
+== Level 1 Section Title
+
+=== Level 2 Section Title
+
+==== Level 3 Section Title
+
+'''
+//hint
+`=` for Level 0, `==` for Level 1, `===` for Level 2 and so on. Don't forget the space after the equals signs.
+
+'''
+// Your input
+Document Title (Level 0)
+
+Level 1 Section Title
+
+Level 1 Section Title
+
+Level 2 Section Title
+
+Level 3 Section Title
+
+
+// next task
+
+''''
+
+AsciiDoc supports automatic heading numbering.
+
+'''
+//solution
+:numbered:
+
+= Document Title (Level 0)
+
+== Level 1 Section Title
+
+== Level 1 Section Title
+
+=== Level 2 Section Title
+
+==== Level 3 Section Title
+
+'''
+//hint
+The `:numbered:` attribute at the top of the document enables automatic numbering.
+
+'''
+= Document Title (Level 0)
+
+== Level 1 Section Title
+
+== Level 1 Section Title
+
+=== Level 2 Section Title
+
+==== Level 3 Section Title
+
+''''
+
+Each heading can be automatically linked.
+
+'''
+//solution
+:sectanchors:
+
+= Document Title (Level 0)
+
+== Level 1 Section Title
+
+== Level 1 Section Title
+
+=== Level 2 Section Title
+
+==== Level 3 Section Title
+
+'''
+//hint
+The `:sectanchors:` attribute adds anchor links to each heading.
+
+'''
+= Document Title (Level 0)
+
+== Level 1 Section Title
+
+== Level 1 Section Title
+
+=== Level 2 Section Title
+
+==== Level 3 Section Title
+
+

--- a/docs/workshop_en/koan_6.adoc
+++ b/docs/workshop_en/koan_6.adoc
@@ -1,0 +1,103 @@
+ifndef::imagesdir[:imagesdir: ../images]
+
+//Recap
+
+=== Source Code
+
+Code blocks are enclosed with four hyphens `----`.
+
+https://docs.asciidoctor.org/asciidoc/latest/verbatim/source-blocks/[📖, role=docs, target=docs]
+
+'''
+//solution
+----
+10 print "Hello World"
+20 goto 10
+----
+
+'''
+//hint
+Four hyphens before and after the code.
+
+'''
+10 print "Hello World"
+20 goto 10
+
+''''
+
+Syntax highlighting is activated with a `[source]` attribute and a language name.
+
+'''
+//solution
+[source, groovy]
+----
+println "Hello World"
+if (true) {
+    println "AsciiDoc is great"
+}
+----
+
+'''
+//hint
+`[source, groovy]` before the hyphens.
+
+'''
+println "Hello World"
+if (true) {
+    println "AsciiDoc is great"
+}
+
+''''
+
+Callouts mark important lines in code with numbered references.
+
+https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/[📖, role=docs, target=docs]
+
+'''
+//solution
+[source, groovy]
+----
+println "Hello World" // <1>
+if (true) {
+    println "AsciiDoc is great" // <2>
+}
+----
+<1> Output to the console
+<2> Conditional output
+
+'''
+//hint
+`// <1>` in the code, `<1> explanation` below the block.
+
+'''
+[source, groovy]
+----
+println "Hello World"
+if (true) {
+    println "AsciiDoc is great"
+}
+----
+Output to the console
+Conditional output
+
+''''
+
+You can also create simple literal blocks without syntax highlighting. Four dots `....` create a literal block.
+
+'''
+//solution
+....
+This is a literal block.
+  Indentation is preserved.
+    No syntax highlighting.
+....
+
+'''
+//hint
+Four dots `....` instead of four hyphens.
+
+'''
+This is a literal block.
+  Indentation is preserved.
+    No syntax highlighting.
+

--- a/docs/workshop_en/koan_7.adoc
+++ b/docs/workshop_en/koan_7.adoc
@@ -1,0 +1,130 @@
+ifndef::imagesdir[:imagesdir: ../images]
+
+//Recap
+
+=== Tables
+
+Tables start and end with `|===`. Each cell starts with `|`.
+
+https://docs.asciidoctor.org/asciidoc/latest/tables/build-a-basic-table/[📖, role=docs, target=docs]
+
+'''
+//solution
+|===
+| Column 1 | Column 2
+
+| Cell A
+| Cell B
+
+| Cell C
+| Cell D
+|===
+
+'''
+//hint
+`|===` as start and end. Each cell with `|`.
+
+'''
+Column 1, Column 2, Cell A, Cell B, Cell C, Cell D
+
+''''
+
+The first row automatically becomes a header when followed by a blank line.
+
+'''
+//solution
+|===
+| Name | Language
+
+| docToolchain
+| Groovy
+
+| dacli
+| Go
+|===
+
+'''
+//hint
+A blank line after the first row turns it into a header.
+
+'''
+|===
+| Name | Language
+| docToolchain
+| Groovy
+| dacli
+| Go
+|===
+
+''''
+
+Column widths can be controlled with the `cols` attribute.
+
+'''
+//solution
+[cols="1,3"]
+|===
+| Short | Description
+
+| SA
+| Semantic Anchors
+
+| DaC
+| Docs-as-Code
+|===
+
+'''
+//hint
+`[cols="1,3"]` before `|===` sets a 1:3 ratio.
+
+'''
+|===
+| Short | Description
+
+| SA
+| Semantic Anchors
+
+| DaC
+| Docs-as-Code
+|===
+
+''''
+
+With `a` as column type, AsciiDoc content can be written directly in cells.
+
+'''
+//solution
+[cols="1,2a"]
+|===
+| Feature | Details
+
+| Lists
+|
+* One
+* Two
+* Three
+
+| Code
+|
+[source]
+----
+println "hi"
+----
+|===
+
+'''
+//hint
+`[cols="1,2a"]` — the `a` stands for AsciiDoc content in that column.
+
+'''
+[cols="1,2"]
+|===
+| Feature | Details
+
+| Lists
+| One, Two, Three
+
+| Code
+| println "hi"
+|===
+

--- a/docs/workshop_en/koan_8.adoc
+++ b/docs/workshop_en/koan_8.adoc
@@ -1,0 +1,74 @@
+ifndef::imagesdir[:imagesdir: ../images]
+
+//Recap
+
+=== Admonitions
+
+Admonitions are highlighted callout blocks. The simplest form: a keyword followed by a colon and text.
+
+https://docs.asciidoctor.org/asciidoc/latest/blocks/admonitions/[📖, role=docs, target=docs]
+
+'''
+//solution
+NOTE: This is a note.
+
+'''
+//hint
+`NOTE:` followed by a space and the text.
+
+'''
+This is a note.
+
+''''
+
+There are five types: NOTE, TIP, WARNING, IMPORTANT, CAUTION.
+
+'''
+//solution
+NOTE: A note for the reader.
+
+TIP: A practical tip.
+
+WARNING: A warning.
+
+IMPORTANT: Important information.
+
+CAUTION: Proceed with caution.
+
+'''
+//hint
+Each keyword followed by `:` and the text.
+
+'''
+A note for the reader.
+
+A practical tip.
+
+A warning.
+
+Important information.
+
+Proceed with caution.
+
+''''
+
+For multi-line admonitions, use the block form with four equals signs.
+
+'''
+//solution
+[WARNING]
+====
+This action cannot be undone.
+
+Please create a backup first.
+====
+
+'''
+//hint
+`[WARNING]` as attribute, then `====` as block delimiter.
+
+'''
+This action cannot be undone.
+
+Please create a backup first.
+

--- a/docs/workshop_en/koan_9.adoc
+++ b/docs/workshop_en/koan_9.adoc
@@ -1,0 +1,76 @@
+ifndef::imagesdir[:imagesdir: ../images]
+
+//Recap
+
+=== Images
+
+Block images are included with `image::`. The filename goes between the double colons and the square brackets.
+
+https://docs.asciidoctor.org/asciidoc/latest/macros/images/[📖, role=docs, target=docs]
+
+'''
+//solution
+image::file.png[]
+
+'''
+//hint
+`image::filename.png[]` — two colons for block images.
+
+'''
+file.png
+
+''''
+
+Images can have a title, alt text and a width.
+
+'''
+//solution
+.A screenshot of the file chooser
+image::file.png[File chooser, width=200]
+
+'''
+//hint
+Title with `.` before the image macro. Alt text and width inside `[]`.
+
+'''
+image::file.png[]
+
+''''
+
+Inline images use only one colon and appear within the text flow.
+
+'''
+//solution
+Click the icon image:file.png[Icon, width=20] to open the file.
+
+'''
+//hint
+`image:filename.png[]` — only one colon for inline images.
+
+'''
+Click the icon to open the file.
+
+''''
+
+Diagrams can be written as PlantUML directly in the document. With Kroki they are rendered automatically.
+
+'''
+//solution
+[plantuml]
+----
+@startuml
+Alice -> Bob: Hello
+Bob -> Alice: Hi!
+@enduml
+----
+
+'''
+//hint
+`[plantuml]` as attribute before the code block.
+
+'''
+@startuml
+Alice -> Bob: Hello
+Bob -> Alice: Hi!
+@enduml
+


### PR DESCRIPTION
## Summary

Complete English translation of all 10 workshop koans, with a DE/EN language switcher.

## Changes

- 10 English koan files in `docs/workshop_en/`
- `workshop_en.html` with `koanFolder = "workshop_en"`
- `workshop.js`: `koanFolder` variable configurable via `window.koanFolder`
- DE/EN toggle buttons in sidebar (both workshop.html and workshop_en.html)
- CSS for `.lang-switch` buttons

## All 68 exercises verified

```
German:  34 exercises, 34 passed, 0 failed, 0 warnings
English: 34 exercises, 34 passed, 0 failed, 0 warnings
```

## Test plan

- [ ] Open workshop.html — German koans load, DE button active
- [ ] Click EN — switches to workshop_en.html, English koans load
- [ ] Click DE — switches back
- [ ] All 10 English koans solvable (exercises turn green)
- [ ] Progress bar shows total correctly in both languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)